### PR TITLE
Handle `maxage` compatibility

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -148,7 +148,7 @@ export default class MongoStore extends EventEmitter {
    * @api public
    */
   *set(sid, sess) {
-    const maxAge = sess.cookie.maxAge;
+    const maxAge = sess.cookie.maxAge || sess.cookie.maxage;
     const col = yield this.col;
     const update = thunkify(col.update.bind(col));
 


### PR DESCRIPTION
Per this commit: [fix maxage compat](https://github.com/koajs/generic-session/commits/master?page=3), `generic-session` uses `cookie.maxage` in lieu of `cookie.maxAge`.

I had to monkey-patch `MongoStore.prototype.set` to work around this:
```javascript
const storeSet = MongoStore.prototype.set

MongoStore.prototype.set = function *(sid, session) {
  if(session.cookie) {
    session.cookie.maxAge = session.cookie.maxage
  }
  return yield storeSet.apply(this, arguments)
}
```